### PR TITLE
feat: make event name and description customizable + add account name as variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,27 @@ All configuration is done through environment variables.
 |SYNC_ID_AS_URL|Set to `true` to use the sync ID as part of the URL to make it safer to expose publicly, just like Google Calendar does|false||
 |ACTUAL_SYNC_PASSWORD|The sync password|false||
 |ACTUAL_PATH|The path to store Actual cache data. The container must have write access to this path.|false|`.actual-cache`|
+|EVENT_NAME_TEMPLATE|Template for the calendar event name. See [Event template variables](#event-template-variables) for available variables|false|`{{scheduleName}} ({{amount}})`|
+|EVENT_DESCRIPTION_TEMPLATE|Template for the calendar event description. See [Event template variables](#event-template-variables) for available variables|false||
 |TZ|The timezone to use on ical data|false|UTC|
 |PORT|The port to listen on|false|3000|
 |LOCALE|The locale to use when formatting amounts|false|en-US|
 |CURRENCY|The currency to use when formatting amounts. Values must be one of [these](https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes)|false|USD|
 |LOG_LEVEL|The log level to use. `trace`, `debug`, `info`, `warn`, `error` or `fatal`|false|`info`|
+
+## Event template variables
+
+The `EVENT_NAME_TEMPLATE` and `EVENT_DESCRIPTION_TEMPLATE` variables control the event title and description respectively. Variables are written as `{{variableName}}` and will be replaced at render time.
+
+|Variable|Description|
+|---|---|
+|`scheduleName`|The name of the scheduled transaction in Actual|
+|`amount`|The transaction amount, formatted according to `LOCALE` and `CURRENCY`|
+|`accountName`|⚠️ The name of the Actual account the schedule belongs to|
+
+> Note: Some variables might not be defined for all events (marked with ⚠️). For example, `accountName` will only be defined for schedules that belong to an account. If a variable is not defined, it will be replaced with an empty string.
+
+> Note 2: Template values are always trimmed, so any leading or trailing whitespace will be removed.
 
 ## Hosting it publicly
 

--- a/src/ical.ts
+++ b/src/ical.ts
@@ -2,7 +2,7 @@ import * as actualApi from '@actual-app/api'
 import ical, { ICalCalendarMethod } from 'ical-generator'
 import { RRule } from 'rrule'
 import { DateTime, DurationLikeObject } from 'luxon'
-import { RecurConfig, ScheduleEntity } from '@actual-app/api/@types/loot-core/src/types/models'
+import { AccountEntity, RecurConfig, ScheduleEntity } from '@actual-app/api/@types/loot-core/src/types/models'
 import { formatCurrency } from './helpers/number'
 import { existsSync, mkdirSync } from 'node:fs'
 import logger from './helpers/logger'
@@ -13,6 +13,8 @@ const {
   ACTUAL_SYNC_ID,
   ACTUAL_SYNC_PASSWORD,
   ACTUAL_PATH = '.actual-cache',
+  EVENT_NAME_TEMPLATE = '{{scheduleName}} ({{amount}})',
+  EVENT_DESCRIPTION_TEMPLATE,
   TZ = 'UTC',
 } = process.env
 
@@ -51,9 +53,29 @@ const getSchedules = async () => {
     })
     .select(['*'])
 
-  const { data } = await actualApi.aqlQuery(query) as { data: ScheduleEntity[] }
+  const accountsQuery = actualApi.q('accounts')
+    .filter({
+      tombstone: false,
+    })
+    .select(['*'])
 
-  return data
+  const { data: schedulesData } = await actualApi.aqlQuery(query) as { data: ScheduleEntity[] }
+
+  const { data: accountsData } = await actualApi.aqlQuery(accountsQuery) as { data: AccountEntity[] }
+
+  const accountsMap = new Map(accountsData.map((account) => [account.id, account]))
+
+  type EnrichedSchedule = ScheduleEntity & {
+    account?: AccountEntity
+  }
+
+  return schedulesData.map((schedule: EnrichedSchedule) => {
+    if (schedule._account) {
+      schedule.account = accountsMap.get(schedule._account)
+    }
+
+    return schedule
+  })
 }
 
 const resolveFrequency = (frequency: string) => {
@@ -248,6 +270,18 @@ export const generateIcal = async () => {
       throw new Error('Invalid weekendSolveMode')
     }
 
+    const renderTemplate = (template: string) => {
+      const variables = {
+        scheduleName: schedule.name,
+        amount: formatAmount(),
+        accountName: schedule.account?.name,
+      }
+
+      return template.replace(/{{(.*?)}}/g, (_, varName) => {
+        return variables[varName as keyof typeof variables] || ''
+      }).trim()
+    }
+
    try {
       return rule.all()
         .filter((date) => {
@@ -256,7 +290,8 @@ export const generateIcal = async () => {
         .map((date) => {
           return calendar.createEvent({
             start: moveOnWeekend(date).toJSDate(),
-            summary: `${schedule.name} (${formatAmount()})`,
+            summary: renderTemplate(EVENT_NAME_TEMPLATE),
+            description: EVENT_DESCRIPTION_TEMPLATE && renderTemplate(EVENT_DESCRIPTION_TEMPLATE),
             allDay: true,
             timezone: TZ,
           })


### PR DESCRIPTION
This adds support for a `EVENT_NAME_TEMPLATE` environment variable that allows users to customize the event names with a template-like approach

Current variables available are:
- `amount`: represents the schedule amount, respecting currency format
- `scheduleName`: the name of the schedule
- `accountName`: the name of the linked account, which can be empty if the schedule entry isn't linked to any account

The default template is `{{scheduleName}} ({{amount}})`, which is the current display format, so no breaking changes on this PR

Closes #29 